### PR TITLE
fixed http content-length panic

### DIFF
--- a/buffer_pool.go
+++ b/buffer_pool.go
@@ -1,0 +1,25 @@
+package timeout
+
+import (
+	"bytes"
+	"sync"
+)
+
+// BufferPool is Pool of *bytes.Buffer
+type BufferPool struct {
+	pool sync.Pool
+}
+
+// Get a bytes.Buffer pointer
+func (p *BufferPool) Get() *bytes.Buffer {
+	buf := p.pool.Get()
+	if buf == nil {
+		return &bytes.Buffer{}
+	}
+	return buf.(*bytes.Buffer)
+}
+
+// Put a bytes.Buffer pointer to BufferPool
+func (p *BufferPool) Put(buf *bytes.Buffer) {
+	p.pool.Put(buf)
+}

--- a/buffer_pool_test.go
+++ b/buffer_pool_test.go
@@ -1,0 +1,16 @@
+package timeout
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetBuffer(t *testing.T) {
+	pool := &BufferPool{}
+	buf := pool.Get()
+	assert.NotEqual(t, nil, buf)
+	pool.Put(buf)
+	buf2 := pool.Get()
+	assert.NotEqual(t, nil, buf2)
+}

--- a/timeout.go
+++ b/timeout.go
@@ -92,6 +92,7 @@ func New(opts ...Option) gin.HandlerFunc {
 		select {
 		case p := <-panicChan:
 			tw.FreeBuffer()
+			c.Writer = w
 			panic(p)
 
 		case <-finish:

--- a/timeout.go
+++ b/timeout.go
@@ -42,6 +42,10 @@ type Timeout struct {
 	response gin.HandlerFunc
 }
 
+var (
+	buffpool *BufferPool
+)
+
 // New wraps a handler and aborts the process of the handler if the timeout is reached
 func New(opts ...Option) gin.HandlerFunc {
 	const (
@@ -64,24 +68,56 @@ func New(opts ...Option) gin.HandlerFunc {
 		return t.handler
 	}
 
+	buffpool = &BufferPool{}
+
 	return func(c *gin.Context) {
-		ch := make(chan struct{}, 1)
+		finish := make(chan struct{}, 1)
+		panicChan := make(chan interface{}, 1)
+
+		w := c.Writer
+		buffer := buffpool.Get()
+		tw := NewWriter(w, buffer)
+		c.Writer = tw
 
 		go func() {
 			defer func() {
-				_ = gin.Recovery()
+				if p := recover(); p != nil {
+					panicChan <- p
+				}
 			}()
 			t.handler(c)
-			ch <- struct{}{}
+			finish <- struct{}{}
 		}()
 
 		select {
-		case <-ch:
+		case p := <-panicChan:
+			tw.FreeBuffer()
+			panic(p)
+
+		case <-finish:
 			c.Next()
+			tw.mu.Lock()
+			defer tw.mu.Unlock()
+			dst := tw.ResponseWriter.Header()
+			for k, vv := range tw.Header() {
+				dst[k] = vv
+			}
+			tw.ResponseWriter.WriteHeader(tw.code)
+			tw.ResponseWriter.Write(buffer.Bytes())
+			tw.FreeBuffer()
+			buffpool.Put(buffer)
+
 		case <-time.After(t.timeout):
-			c.AbortWithStatus(http.StatusRequestTimeout)
+			c.Abort()
+			tw.mu.Lock()
+			defer tw.mu.Unlock()
+			tw.timeout = true
+			tw.FreeBuffer()
+			buffpool.Put(buffer)
+
+			c.Writer = w
 			t.response(c)
-			return
+			c.Writer = tw
 		}
 	}
 }

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -78,3 +78,23 @@ func TestSuccess(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "", w.Body.String())
 }
+
+func panicResponse(c *gin.Context) {
+	panic("test")
+}
+
+func TestPanic(t *testing.T) {
+	r := gin.New()
+	r.Use(gin.Recovery())
+	r.GET("/", New(
+		WithTimeout(1*time.Second),
+		WithHandler(panicResponse),
+	))
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, "", w.Body.String())
+}

--- a/timeout_writer.go
+++ b/timeout_writer.go
@@ -1,0 +1,70 @@
+package timeout
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Writer is a writer with memory buffer
+type Writer struct {
+	gin.ResponseWriter
+	body         *bytes.Buffer
+	headers      http.Header
+	mu           sync.Mutex
+	timeout      bool
+	wroteHeaders bool
+	code         int
+}
+
+// NewWriter will return a timeout.Writer pointer
+func NewWriter(w gin.ResponseWriter, buf *bytes.Buffer) *Writer {
+	return &Writer{ResponseWriter: w, body: buf, headers: make(http.Header)}
+}
+
+func (w *Writer) Write(data []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.timeout || w.body == nil {
+		return 0, nil
+	}
+
+	return w.body.Write(data)
+}
+
+func (w *Writer) WriteHeader(code int) {
+	checkWriteHeaderCode(code)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.timeout || w.wroteHeaders {
+		return
+	}
+	w.writeHeader(code)
+}
+
+func (w *Writer) writeHeader(code int) {
+	w.wroteHeaders = true
+	w.code = code
+}
+
+func (w *Writer) Header() http.Header {
+	return w.headers
+}
+
+func (w *Writer) WriteString(s string) (int, error) {
+	return w.Write([]byte(s))
+}
+
+// FreeBuffer will release buffer pointer
+func (w *Writer) FreeBuffer() {
+	w.body = nil
+}
+
+func checkWriteHeaderCode(code int) {
+	if code < 100 || code > 999 {
+		panic(fmt.Sprintf("invalid http status code: %d", code))
+	}
+}

--- a/writer.go
+++ b/writer.go
@@ -25,6 +25,7 @@ func NewWriter(w gin.ResponseWriter, buf *bytes.Buffer) *Writer {
 	return &Writer{ResponseWriter: w, body: buf, headers: make(http.Header)}
 }
 
+// Write will write data to response body
 func (w *Writer) Write(data []byte) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -35,6 +36,7 @@ func (w *Writer) Write(data []byte) (int, error) {
 	return w.body.Write(data)
 }
 
+// WriteHeader will write http status code
 func (w *Writer) WriteHeader(code int) {
 	checkWriteHeaderCode(code)
 	w.mu.Lock()
@@ -50,10 +52,12 @@ func (w *Writer) writeHeader(code int) {
 	w.code = code
 }
 
+// Header will get response headers
 func (w *Writer) Header() http.Header {
 	return w.headers
 }
 
+// WriteString will write string to response body
 func (w *Writer) WriteString(s string) (int, error) {
 	return w.Write([]byte(s))
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,0 +1,23 @@
+package timeout
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteHeader(t *testing.T) {
+	code1 := 99
+	errmsg1 := fmt.Sprintf("invalid http status code: %d", code1)
+	code2 := 1000
+	errmsg2 := fmt.Sprintf("invalid http status code: %d", code2)
+
+	writer := Writer{}
+	assert.PanicsWithValue(t, errmsg1, func() {
+		writer.WriteHeader(code1)
+	})
+	assert.PanicsWithValue(t, errmsg2, func() {
+		writer.WriteHeader(code2)
+	})
+}


### PR DESCRIPTION
I use bytes.Buffer to temporarily buffer the write of the handler, and then write to gin.ResponseWriter after the processing is successful, thus fixing #1 .
But when the Handler's Response is particularly large, it will take up a lot of memory, which I haven't solved temporarily. 