### PR TITLE
fix(response): conflict when handler completed and timed out

### DIFF
--- a/timeout.go
+++ b/timeout.go
@@ -85,9 +85,9 @@ func New(opts ...Option) gin.HandlerFunc {
 			tw.FreeBuffer()
 			bufPool.Put(buffer)
 
-			c.Writer = w
-			t.response(c)
-			c.Writer = tw
+			cc := c.Copy()
+			cc.Writer = w
+			t.response(cc)
 		}
 	}
 }


### PR DESCRIPTION
This fixes response conflict when an inner handler and the timeout handler write responses at the same time.

close #40 