### PR TITLE
Extend default timeout on certain path patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 .idea
+.vscode
+
+# Environment
+.env

--- a/README.md
+++ b/README.md
@@ -102,3 +102,49 @@ func main() {
 	}
 }
 ```
+
+### extended timeout on certain paths
+
+```go
+package main
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gin-contrib/timeout"
+	"github.com/gin-gonic/gin"
+)
+
+func testResponse(c *gin.Context) {
+	c.String(http.StatusRequestTimeout, "timeout")
+}
+
+func extendedTimeoutMiddleware() gin.HandlerFunc {
+	return timeout.New(
+		timeout.WithTimeout(200*time.Millisecond),          // Default timeout on all routes
+		timeout.WithExtendedTimeout(1000*time.Millisecond), // Extended timeout on pattern based routes
+		timeout.WithExtendedPaths([]string{
+			"/ext.*", // List of patterns to allow extended timeouts
+		}),      
+		timeout.WithHandler(func(c *gin.Context) {
+			c.Next()
+		}),
+		timeout.WithResponse(testResponse),
+	)
+}
+
+func main() {
+	r := gin.New()
+	r.Use(extendedTimeoutMiddleware())
+	r.GET("/extended", func(c *gin.Context) {
+		time.Sleep(800 * time.Millisecond)
+		c.Status(http.StatusOK)
+	})
+
+	if err := r.Run(":8080"); err != nil {
+		log.Fatal(err)
+	}
+}
+```

--- a/_example/example03/main.go
+++ b/_example/example03/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gin-contrib/timeout"
+	"github.com/gin-gonic/gin"
+)
+
+func testResponse(c *gin.Context) {
+	c.String(http.StatusRequestTimeout, "timeout")
+}
+
+func extendedTimeoutMiddleware() gin.HandlerFunc {
+	return timeout.New(
+		timeout.WithTimeout(200*time.Millisecond),          // Default timeout on all routes
+		timeout.WithExtendedTimeout(1000*time.Millisecond), // Extended timeout on pattern based routes
+		timeout.WithExtendedPaths([]string{"/ext.*"}),      // List of patterns to allow extended timeouts
+		timeout.WithHandler(func(c *gin.Context) {
+			c.Next()
+		}),
+		timeout.WithResponse(testResponse),
+	)
+}
+
+func main() {
+	r := gin.New()
+	r.Use(extendedTimeoutMiddleware())
+	r.GET("/extended", func(c *gin.Context) {
+		time.Sleep(800 * time.Millisecond)
+		c.Status(http.StatusOK)
+	})
+
+	if err := r.Run(":8080"); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
# Summary

We ran into a use case where certain longer running endpoints needed their timeout to be extended beyond what the rest of the API required due to longer running legacy processes that couldn't be changed for backwards compatibility. There was a limitation in this middleware package that we couldn't easily extend certain paths from the normal timeout.

Extending certain paths, path patterns or lists of paths allows us to configure endpoints in a more controlled way, instead of updating the whole app to allow longer running timeouts.

## Changes

- Added a functional option to set the extended default timeout: 

```go
func WithExtendedTimeout(extendedTimeout time.Duration) Option
```

- Added a functional option to set the list of paths that can be extended:

```go
func WithExtendedPaths(extendedPaths []string) Option
``` 

- Added a check against the set list of path patterns which will extend the timeout for that path only.
- If no extended paths have been set, the normal `timeout` will be used.
- Added tests to cover success and timeout states when using extended options.
- Added example and readme updates

## Example Usage

```go
package main

import (
	"log"
	"net/http"
	"time"

	"github.com/gin-contrib/timeout"
	"github.com/gin-gonic/gin"
)

func testResponse(c *gin.Context) {
	c.String(http.StatusRequestTimeout, "timeout")
}

func extendedTimeoutMiddleware() gin.HandlerFunc {
	return timeout.New(
		timeout.WithTimeout(200*time.Millisecond),          // Default timeout on all routes
		timeout.WithExtendedTimeout(1000*time.Millisecond), // Extended timeout on pattern based routes
		timeout.WithExtendedPaths([]string{"/ext.*"}),      // List of patterns to allow extended timeouts
		timeout.WithHandler(func(c *gin.Context) {
			c.Next()
		}),
		timeout.WithResponse(testResponse),
	)
}

func main() {
	r := gin.New()
	r.Use(extendedTimeoutMiddleware())
	r.GET("/extended", func(c *gin.Context) {
		time.Sleep(800 * time.Millisecond)
		c.Status(http.StatusOK)
	})

	if err := r.Run(":8080"); err != nil {
		log.Fatal(err)
	}
}
```
