### PR TITLE
fix(context): (context.Context).Err() returns DeadlineExceeded

### DIFF
--- a/timeout_test.go
+++ b/timeout_test.go
@@ -2,8 +2,11 @@ package timeout
 
 import (
 	"context"
+	"crypto/tls"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -99,4 +102,105 @@ func TestPanic(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Equal(t, "", w.Body.String())
+}
+
+func TestDeadlineExceeded(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	r := gin.New()
+	r.GET("/", New(
+		WithTimeout(50*time.Millisecond),
+		WithHandler(func(c *gin.Context) {
+			defer wg.Done()
+			time.Sleep(100 * time.Millisecond)
+			assert.Equal(t, "value", c.Request.Header.Get("X-Test"))
+			// This context is canceled by calling `w.cancelCtx()` in http.Server.serve().
+			assert.Equal(t, context.Canceled, c.Request.Context().Err())
+			select {
+			case <-c.Request.Context().Done():
+				// OK
+			case <-time.After(1 * time.Second):
+				assert.Fail(t, "context is not done")
+			}
+		}),
+		WithResponse(func(c *gin.Context) {
+			c.String(http.StatusRequestTimeout, "timeout")
+		}),
+	))
+
+	srv := &http.Server{
+		Addr:              ":3124",
+		Handler:           r,
+		ReadHeaderTimeout: 1 * time.Second,
+	}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			assert.Error(t, err)
+		}
+	}()
+
+	// have to wait for the goroutine to start and run the server
+	// otherwise the main thread will complete
+	time.Sleep(5 * time.Millisecond)
+
+	testRequest(
+		t,
+		"http://localhost:3124",
+		"408 Request Timeout",
+		"timeout",
+	)
+
+	wg.Wait()
+
+	if err := srv.Close(); err != nil {
+		assert.Fail(t, "Server Close: "+err.Error())
+	}
+}
+
+// params[0]=url example:http://127.0.0.1:8080/index (cannot be empty)
+// params[1]=response status (custom compare status) default:"200 OK"
+// params[2]=response body (custom compare content)  default:"it worked"
+func testRequest(t *testing.T, params ...string) {
+	if len(params) == 0 {
+		t.Fatal("url cannot be empty")
+	}
+
+	req, err := http.NewRequest(
+		"GET",
+		params[0],
+		nil,
+	)
+	assert.NoError(t, err)
+
+	header := http.Header{}
+	header.Set("X-Test", "value")
+	req.Header = header
+
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	client := &http.Client{Transport: tr}
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, ioerr := io.ReadAll(resp.Body)
+	assert.NoError(t, ioerr)
+
+	responseStatus := "200 OK"
+	if len(params) > 1 && params[1] != "" {
+		responseStatus = params[1]
+	}
+
+	responseBody := "it worked"
+	if len(params) > 2 && params[2] != "" {
+		responseBody = params[2]
+	}
+
+	assert.Equal(t, responseStatus, resp.Status, "should get a "+responseStatus)
+	assert.Equal(t, responseBody, string(body), "resp body should match")
 }

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -115,8 +115,7 @@ func TestDeadlineExceeded(t *testing.T) {
 			defer wg.Done()
 			time.Sleep(100 * time.Millisecond)
 			assert.Equal(t, "value", c.Request.Header.Get("X-Test"))
-			// This context is canceled by calling `w.cancelCtx()` in http.Server.serve().
-			assert.Equal(t, context.Canceled, c.Request.Context().Err())
+			assert.Equal(t, context.DeadlineExceeded, c.Request.Context().Err())
 			select {
 			case <-c.Request.Context().Done():
 				// OK


### PR DESCRIPTION
# Overview

Currently, when a timeout occurs, the ctx.Request.Context().Err() method returns a context.Canceled. However, in the case of a timeout, we expect the context.DeadlineExceeded to be returned.

This pull request addresses the timeout error handling. By modifying to return context.DeadlineExceeded when a timeout occurs, we enhance the consistency of error handling.

```
r := gin.New()
r.GET("/", timeout.New(
	timeout.WithTimeout(50*time.Millisecond),
	timeout.WithHandler(func(c *gin.Context) {
		time.Sleep(100 * time.Millisecond)

		// expected: context.DeadlineExceeded
		// actual: context.Canceled
		fmt.Printf("%v\n", c.Request.Context().Err())
	}),
))
r.Run("0.0.0.0:8083")
```

# Changes Made

Reviewed and revised timeout error handling to return the context.DeadlineExceeded instead of the context.Canceled  using ctx.Request.Context().Err().


# Testing

Added test cases that trigger timeouts with the applied changes. This ensures that the modifications function correctly and the expected error is returned.