### PR TITLE
fix(response): conflict when handler completed and concurrent map writes

### DIFF
--- a/timeout.go
+++ b/timeout.go
@@ -85,9 +85,9 @@ func New(opts ...Option) gin.HandlerFunc {
 			tw.FreeBuffer()
 			bufPool.Put(buffer)
 
-			c.Writer = w
-			t.response(c)
-			c.Writer = tw
+			cc := c.Copy()
+			cc.Writer = w
+			t.response(cc)
 		}
 	}
 }


### PR DESCRIPTION
Resolve the #15 `fatal error: concurrent map writes` issue

## Cause

In the current implementation, when a timeout occurs, `c.Writer` is replaced with `&gin.responseWriter` and writing to the Body is performed by the `Timeout.response` handler.

Subsequently, additional writes to the `Body` are performed by the handler being executed in a goroutine.

This results in writes being performed to the `Body` in a duplicate manner.

## Countermeasure

Before replacing `c.Writer`, use `*gin.Context.Copy()` to duplicate the context. This ensures that `c.Writer` is only set to `&gin.responseWriter` when `Timeout.response` handler is executed.


## Verification

Execute the following verification code.

```golang
func main() {
	r := gin.New()
	r.GET(
		"/timeout",
		timeout.New(timeout.WithTimeout(200*time.Microsecond),
			timeout.WithHandler(func(c *gin.Context) {
				time.Sleep(150 * time.Microsecond)
				c.JSON(http.StatusOK, gin.H{"code": 200, "data": ""})
			}),
			timeout.WithResponse(func(c *gin.Context) {
				c.JSON(http.StatusRequestTimeout, gin.H{"code": 408, "message": "test"})
			})),
	)
	if err := r.Run(":8080"); err != nil {
		log.Fatal(err)
	}
}
```

Request 20 times consecutively using the following command.

```sh
for i in {1..20} ; do curl localhost:8080/timeout; echo ""; done
```

Before the fix, there were instances of duplicated `Body` content. Additionally, the application occasionally encountered a `fatal error: concurrent map writes` and would stop.

```sh
% for i in {1..20} ; do curl localhost:8080/timeout; echo ""; done
{"code":200,"data":""}
{"code":408,"message":"test"}
{"code":408,"message":"test"}{"code":200,"data":""}
{"code":408,"message":"test"}{"code":200,"data":""}
{"code":200,"data":""}
{"code":200,"data":""}{"code":408,"message":"test"}
{"code":408,"message":"test"}
{"code":408,"message":"test"}
{"code":200,"data":""}
{"code":408,"message":"test"}
{"code":408,"message":"test"}
{"code":408,"message":"test"}
{"code":408,"message":"test"}
{"code":200,"data":""}
{"code":408,"message":"test"}{"code":200,"data":""}
curl: (52) Empty reply from server

curl: (7) Failed to connect to localhost port 8080 after 7 ms: Couldn't connect to server

curl: (7) Failed to connect to localhost port 8080 after 6 ms: Couldn't connect to server

curl: (7) Failed to connect to localhost port 8080 after 7 ms: Couldn't connect to server

curl: (7) Failed to connect to localhost port 8080 after 7 ms: Couldn't connect to server
```

After the fix, there is no duplication of the `Body`, and the application does not encounter a `fatal error: concurrent map writes` that would cause it to stop.

```
{"code":200,"data":""}
{"code":200,"data":""}
{"code":200,"data":""}
{"code":408,"message":"test"}
{"code":408,"message":"test"}
{"code":408,"message":"test"}
{"code":408,"message":"test"}
{"code":408,"message":"test"}
{"code":408,"message":"test"}
{"code":408,"message":"test"}
{"code":408,"message":"test"}
{"code":408,"message":"test"}
{"code":408,"message":"test"}
{"code":200,"data":""}
{"code":408,"message":"test"}
{"code":408,"message":"test"}
{"code":408,"message":"test"}
{"code":200,"data":""}
{"code":408,"message":"test"}
{"code":408,"message":"test"}
```
