### PR TITLE
fix golangci-lint(depguard) errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,5 +39,23 @@ linters:
     - whitespace
     - gofumpt
 
+linters-settings:
+  depguard:
+    rules:
+      Main:
+        files:
+          - $all
+          - "!$test"
+        allow:
+          - $gostd
+          - github.com/gin-gonic/gin
+      Test:
+        files:
+          - $test
+        allow:
+          - $gostd
+          - github.com/gin-gonic/gin
+          - github.com/stretchr/testify
+
 run:
   timeout: 3m


### PR DESCRIPTION
Add [depguard setting](https://golangci-lint.run/usage/linters/#depguard) to the `linters-settings` of the `.golangci.yml` file to fix the following errors that occur in the `Run Tests` workflow.

```
Error: import 'github.com/gin-gonic/gin' is not allowed from list 'Main' (depguard)
Error: import 'github.com/gin-gonic/gin' is not allowed from list 'Main' (depguard)
Error: import 'github.com/gin-gonic/gin' is not allowed from list 'Main' (depguard)
Error: import 'github.com/stretchr/testify/assert' is not allowed from list 'Main' (depguard)
Error: import 'github.com/stretchr/testify/assert' is not allowed from list 'Main' (depguard)
Error: import 'github.com/stretchr/testify/assert' is not allowed from list 'Main' (depguard)
```