### PR TITLE
refactor: refactor timeout handling in timeout.go and timeout_test.go

### DIFF
--- a/timeout.go
+++ b/timeout.go
@@ -1,7 +1,6 @@
 package timeout
 
 import (
-	"context"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -47,10 +46,6 @@ func New(opts ...Option) gin.HandlerFunc {
 		c.Writer = tw
 		buffer.Reset()
 
-		ctx, cancel := context.WithTimeout(c, t.timeout)
-		c.Request = c.Request.WithContext(ctx)
-		defer cancel()
-
 		go func() {
 			defer func() {
 				if p := recover(); p != nil {
@@ -82,7 +77,7 @@ func New(opts ...Option) gin.HandlerFunc {
 			tw.FreeBuffer()
 			bufPool.Put(buffer)
 
-		case <-c.Request.Context().Done():
+		case <-time.After(t.timeout):
 			c.Abort()
 			tw.mu.Lock()
 			defer tw.mu.Unlock()


### PR DESCRIPTION
- Remove the import statement for "context" in timeout.go
- Remove the code block related to context cancellation in the New function in timeout.go
- Replace the case statement in the New function in timeout.go with a case statement using time.After
- Remove the import statement for "sync" in timeout_test.go
- Remove the TestDeadlineExceeded function in timeout_test.go

reverted PR #54 