### PR TITLE
fix: make set/read timeout and write/put buffer atomic

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -27,12 +27,12 @@ func NewWriter(w gin.ResponseWriter, buf *bytes.Buffer) *Writer {
 
 // Write will write data to response body
 func (w *Writer) Write(data []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	if w.timeout || w.body == nil {
 		return 0, nil
 	}
-
-	w.mu.Lock()
-	defer w.mu.Unlock()
 
 	return w.body.Write(data)
 }
@@ -41,6 +41,9 @@ func (w *Writer) Write(data []byte) (int, error) {
 // If the response writer has already written headers or if a timeout has occurred,
 // this method does nothing.
 func (w *Writer) WriteHeader(code int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	if w.timeout || w.wroteHeaders {
 		return
 	}
@@ -52,9 +55,6 @@ func (w *Writer) WriteHeader(code int) {
 	}
 
 	checkWriteHeaderCode(code)
-
-	w.mu.Lock()
-	defer w.mu.Unlock()
 
 	w.writeHeader(code)
 	w.ResponseWriter.WriteHeader(code)


### PR DESCRIPTION
When I ran stress testing in prod environment, I found the buffer which is used by current request will be written by the previous request which has timeout.
I found that setting `tw.timeout = true` and put buffer to pool is guarded by sync.mutex:
https://github.com/gin-contrib/timeout/blob/c9f1fc9648482a03867dae552b1ef630600bb03c/timeout.go#L82-L86
But reading timeout is unsafed, so that it may cause a data race? I think set/read timeout and write/put buffer should be atomic, otherwise it will cause writing buffer which has already been put back to pool.
https://github.com/gin-contrib/timeout/blob/c9f1fc9648482a03867dae552b1ef630600bb03c/writer.go#L29-L61