### PR TITLE
fix: prevent middleware execution after request timeout

### DIFF
--- a/timeout.go
+++ b/timeout.go
@@ -63,7 +63,6 @@ func New(opts ...Option) gin.HandlerFunc {
 			panic(p)
 
 		case <-finish:
-			c.Next()
 			tw.mu.Lock()
 			defer tw.mu.Unlock()
 			dst := tw.ResponseWriter.Header()


### PR DESCRIPTION
- Remove call to c.Next() to prevent execution of subsequent middleware after a timeout
- Update test to use a longer sleep and return StatusBadRequest instead of StatusRequestTimeout
- Add a new test to verify that middleware after a timeout is not executed