### PR TITLE
fix: refactor Gin context and timeout handling for safer concurrency

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -34,6 +34,13 @@ func (w *Writer) WriteHeaderNow() {
 		if w.code == 0 {
 			w.code = http.StatusOK
 		}
+
+		// Copy headers from our cache to the underlying ResponseWriter
+		dst := w.ResponseWriter.Header()
+		for k, vv := range w.headers {
+			dst[k] = vv
+		}
+
 		w.WriteHeader(w.code)
 	}
 }
@@ -68,6 +75,12 @@ func (w *Writer) WriteHeader(code int) {
 	}
 
 	checkWriteHeaderCode(code)
+
+	// Copy headers from our cache to the underlying ResponseWriter
+	dst := w.ResponseWriter.Header()
+	for k, vv := range w.headers {
+		dst[k] = vv
+	}
 
 	w.writeHeader(code)
 	w.ResponseWriter.WriteHeader(code)


### PR DESCRIPTION
- Add a check to panic if the timeout handler is not set
- Prevent data races by copying the Gin context before running the handler in a goroutine
- Ensure the copied context uses the timeout writer for proper response buffering
- Change panic propagation to re-throw the original panic value instead of the wrapper
- Write the buffered response and status code only if set, and only if there is content
- Refactor timeout handling to only send the timeout response if headers have not been written, and abort with HTTP 408 status
- In tests, move handler logic into middleware and reduce the number of iterations in a loop from 100 to 10
- In the writer, ensure cached headers are copied to the underlying ResponseWriter before writing headers or status code

fix https://github.com/gin-contrib/timeout/issues/15