### PR TITLE
fix: restore original writer so unmatched routes still return 404

### DIFF
--- a/timeout.go
+++ b/timeout.go
@@ -150,7 +150,12 @@ func New(opts ...Option) gin.HandlerFunc {
 			case <-panicChan:
 			}
 
-			// Goroutine is done. Safe to modify c.index now.
+			// Goroutine is done. Safe to modify c and c.index now. Restoring the
+			// writer matters here too: FreeBuffer left tw reporting Size() == -1,
+			// so middleware that inspects c.Writer after c.Next() - gin's own
+			// logger reading BodySize, for one - would read that instead of the
+			// timeout response actually written to w.
+			c.Writer = w
 			c.Abort()
 		}
 	}

--- a/timeout.go
+++ b/timeout.go
@@ -122,6 +122,11 @@ func New(opts ...Option) gin.HandlerFunc {
 			}
 			tw.FreeBuffer()
 			bufPool.Put(buffer)
+			// Restore the original writer so anything gin writes after this
+			// middleware returns - such as the default 404 body from
+			// serveError() when no route matched - reaches the real
+			// ResponseWriter instead of the freed buffer.
+			c.Writer = w
 
 		case <-timer.C:
 			tw.mu.Lock()

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -331,3 +331,26 @@ func TestMethodNotAllowedWithUse(t *testing.T) {
 	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
 	assert.Equal(t, "405 method not allowed", w.Body.String())
 }
+
+func TestOuterMiddlewareSeesResponseSize(t *testing.T) {
+	var size int
+	r := gin.New()
+	// Runs before the timeout middleware, so after c.Next() it reads whatever
+	// writer was left on the context - the same position as gin.Logger().
+	r.Use(func(c *gin.Context) {
+		c.Next()
+		size = c.Writer.Size()
+	})
+	r.Use(New(
+		WithTimeout(5 * time.Millisecond),
+	))
+	r.GET("/", emptySuccessResponse)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusRequestTimeout, w.Code)
+	assert.Equal(t, len(http.StatusText(http.StatusRequestTimeout)), size,
+		"outer middleware should see the size of the timeout response, not the freed buffer")
+}

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -296,3 +296,38 @@ func TestContextDeadlineSet(t *testing.T) {
 	assert.True(t, hasDeadline, "request context should have a deadline set by the middleware")
 	assert.Equal(t, http.StatusOK, w.Code)
 }
+
+func TestNoRouteWithUse(t *testing.T) {
+	r := gin.New()
+	r.Use(New(
+		WithTimeout(1 * time.Second),
+	))
+	r.GET("/hello", func(c *gin.Context) {
+		c.String(http.StatusOK, "world")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "/no/such/route", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, "404 page not found", w.Body.String())
+}
+
+func TestMethodNotAllowedWithUse(t *testing.T) {
+	r := gin.New()
+	r.HandleMethodNotAllowed = true
+	r.Use(New(
+		WithTimeout(1 * time.Second),
+	))
+	r.GET("/hello", func(c *gin.Context) {
+		c.String(http.StatusOK, "world")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", "/hello", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	assert.Equal(t, "405 method not allowed", w.Body.String())
+}


### PR DESCRIPTION
Closes #87

## The bug

With the middleware registered globally via `Use()`, any request that doesn't match a route gets `200 OK` with an empty body instead of gin's `404 page not found`. Gin's own logger still prints 404, so the log and the wire disagree.

```console
$ curl -si http://127.0.0.1:8080/no/such/route
HTTP/1.1 200 OK
Content-Type: text/plain
Content-Length: 0
```

## Why

Gin handles a no-route request in `serveError()`:

https://github.com/gin-gonic/gin/blob/v1.12.0/gin.go#L764-L779

```go
func serveError(c *Context, code int, defaultMessage []byte) {
	c.writermem.status = code
	c.Next()                     // <- the middleware runs here
	if c.writermem.Written() { return }
	if c.writermem.Status() == code {
		c.writermem.Header()["Content-Type"] = mimePlain
		_, err := c.Writer.Write(defaultMessage)   // <- c.Writer is still the timeout Writer
		...
```

The status goes on `c.writermem` before the middleware runs, and the body is written through `c.Writer` after it returns. The `case <-finish:` branch called `FreeBuffer()` (setting `body = nil`) but left `c.Writer` pointing at the timeout `Writer`, so:

- `Write` hit the `w.body == nil` guard and returned `(0, nil)` — the 404 body was silently dropped
- `tw.code` was 0, so no status was flushed either, and `net/http` sent an implicit 200
- the `Content-Type: text/plain` in the response comes from `c.writermem.Header()`, which is why the empty reply still looks like a text response

Registering per-route (as in `_example/example01`) doesn't hit this, because route handlers never run for unmatched routes — which is why the examples never caught it.

## The fix

Restore `c.Writer` to the original writer once the buffer is flushed, the same way the panic branch on line 88 already does.

`HandleMethodNotAllowed` goes through the same `serveError` path, so the 405 response was broken in exactly the same way and is fixed by the same line.

## Before / after

Same test, only `timeout.go` stashed:

| path | before | after |
| --- | --- | --- |
| unmatched route | `200 ""` | `404 "404 page not found"` |
| 405 method not allowed | `200 ""` | `405 "405 method not allowed"` |
| matched route | `200 "world"` | unchanged |
| custom `NoRoute` handler | `404 {"err":"nope"}` | unchanged |
| unmatched + timed out | `408 "Request Timeout"` | unchanged |

Custom `NoRoute` handlers were never affected — they write through `c.Writer` while the buffer is still live, so the flush picks them up.

Added `TestNoRouteWithUse` and `TestMethodNotAllowedWithUse`. `go test -race ./...` and `go vet ./...` pass.